### PR TITLE
Remove compat bounds for libcxxwrap_julia_jll again

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -7,13 +7,10 @@ version = "0.1.5"
 CxxWrap = "1f15a43c-97ca-5a2a-ae31-89f07a497df4"
 Preferences = "21216c6a-2e73-6563-6e65-726566657250"
 UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
-libcxxwrap_julia_jll = "3eaa8342-bff7-56a5-9981-c04077f7cee7"
 openfhe_julia_jll = "e5e97983-1b8c-50fe-92b7-0e05c8c202e2"
 
 [compat]
 CxxWrap = "0.14"
 Preferences = "1"
 UUIDs = "1"
-libcxxwrap_julia_jll = "< 0.12"
-openfhe_julia_jll = "< 0.2.3"
 julia = "1.8"


### PR DESCRIPTION
With https://github.com/JuliaPackaging/Yggdrasil/pull/7983 this should not be necessary anymore