### PR TITLE
Add missing docstrings to `CryptoContext`

### DIFF
--- a/src/convenience.jl
+++ b/src/convenience.jl
@@ -309,3 +309,18 @@ function GetBootstrapDepth(level_budget::Vector{<:Integer}, secret_key_distribut
     Int(GetBootstrapDepth(CxxWrap.StdVector(UInt32.(level_budget)), secret_key_distribution))
 end
 
+"""
+    EvalSumKeyGen(crypto_context::CryptoContext, private_key::PrivateKey;
+                  public_key::PublicKey = C_NULL)
+
+Generates the key map to be used by [`EvalSum`](@ref). `public_key` has to be set for NTRU schemes.
+                  
+Please refer to the OpenFHE documentation for more details.
+                  
+See also: [`CryptoContext`](@ref), [`PrivateKey`](@ref), [`PublicKey`](@ref), [`EvalSum`](@ref)
+"""
+function EvalSumKeyGen(context::CxxWrap.CxxWrapCore.CxxRef{OpenFHE.CryptoContextImpl{OpenFHE.DCRTPoly}},
+                       privateKey;
+                       publicKey = OpenFHE.CxxWrap.StdLib.SharedPtr{OpenFHE.PublicKeyImpl{OpenFHE.DCRTPoly}}())
+    EvalSumKeyGen(context, privateKey, publicKey)
+end

--- a/src/documentation.jl
+++ b/src/documentation.jl
@@ -166,7 +166,7 @@ See also: [`CryptoContext`](@ref)
 GetCyclotomicOrder
 
 """
-    GetModulus(crypto_context::CryptoContext)::Integer
+    GetModulus(crypto_context::CryptoContext)::UInt32
 
 Return the ciphertext modulus used for a given `crypto_context`.
 
@@ -184,7 +184,7 @@ See also: [`CryptoContext`](@ref)
 GetRingDimension
 
 """
-    GetRootOfUnity(crypto_context::CryptoContext)::Integer
+    GetRootOfUnity(crypto_context::CryptoContext)::UInt32
 
 Return the root of unity used for a given `crypto_context`.
 

--- a/src/documentation.jl
+++ b/src/documentation.jl
@@ -410,7 +410,7 @@ ModReduceInPlace
 
 """
     EvalSin(crypto_context::CryptoContext, ciphertext::Ciphertext, a::Float64, b::Float64,
-            degree::UInt32)
+            degree::Integer)
 
 Evaluate approximate sine function on a given `ciphertext` using the Chebyshev approximation over
 the range ``[a,b]``. Return the resulting [`Ciphertext`](@ref). The input ciphertext needs to be

--- a/src/documentation.jl
+++ b/src/documentation.jl
@@ -424,7 +424,7 @@ derived from the given `crypto_context`.
 
 Supported only in CKKS.
 
-See also: [`CryptoContext`](@ref), [`Ciphertext`](@ref)
+See also: [`CryptoContext`](@ref), [`Ciphertext`](@ref), [`EvalCos`](@ref)
 """
 EvalSin
 

--- a/src/documentation.jl
+++ b/src/documentation.jl
@@ -450,7 +450,7 @@ EvalCos
 
 """
     EvalLogistic(crypto_context::CryptoContext, ciphertext::Ciphertext, a::Float64, b::Float64,
-                 degree::UInt32)
+                 degree::Integer)
 
 Evaluate approximate logistic function ``\\frac{1}{1 + \\exp{-x}}`` on a given `ciphertext` using
 the Chebyshev approximation over the range ``[a,b]``. Return the resulting [`Ciphertext`](@ref).

--- a/src/documentation.jl
+++ b/src/documentation.jl
@@ -509,7 +509,7 @@ EvalSumKeyGen
 Calculate sum of all elements contained in the given `ciphertext` and return the resulting
 [`Ciphertext`](@ref). The input ciphertext needs to be derived from the given `crypto_context`.
 
-See also: [`CryptoContext`](@ref), [`Ciphertext`](@ref)
+See also: [`CryptoContext`](@ref), [`Ciphertext`](@ref), [`EvalSumKeyGen`](@ref)
 """
 EvalSum
 

--- a/src/documentation.jl
+++ b/src/documentation.jl
@@ -137,6 +137,44 @@ See also: [`CryptoContext`](@ref), [`PKESchemeFeature`](@ref)
 Enable
 
 """
+    GetKeyGenLevel(crypto_context::CryptoContext)::Unsigned
+
+For future use: Return level at which evaluation keys should be generated for the given
+`crypto_context`.
+
+See also: [`CryptoContext`](@ref)
+"""
+GetKeyGenLevel
+
+"""
+    SetKeyGenLevel(crypto_context::CryptoContext, level::Unsigned)
+
+For future use: Set `level` at which evaluation keys should be generated for the given
+`crypto_context`.
+
+See also: [`CryptoContext`](@ref)
+"""
+SetKeyGenLevel
+
+"""
+    GetCyclotomicOrder(crypto_context::CryptoContext)::UInt32
+
+Return the cyclotomic order used for a given `crypto_context`.
+
+See also: [`CryptoContext`](@ref)
+"""
+GetCyclotomicOrder
+
+"""
+    GetModulus(crypto_context::CryptoContext)::Integer
+
+Return the ciphertext modulus used for a given `crypto_context`.
+
+See also: [`CryptoContext`](@ref)
+"""
+GetModulus
+
+"""
     GetRingDimension(crypto_context::CryptoContext)::UInt32
 
 Return the polynomial ring dimension for a given `crypto_context`.
@@ -144,6 +182,15 @@ Return the polynomial ring dimension for a given `crypto_context`.
 See also: [`CryptoContext`](@ref)
 """
 GetRingDimension
+
+"""
+    GetRootOfUnity(crypto_context::CryptoContext)::Integer
+
+Return the root of unity used for a given `crypto_context`.
+
+See also: [`CryptoContext`](@ref)
+"""
+GetRootOfUnity
 
 """
     KeyGen(crypto_context::CryptoContext)
@@ -244,6 +291,46 @@ See also: [`CryptoContext`](@ref), [`Ciphertext`](@ref), [`Plaintext`](@ref)
 """
 EvalMult
 
+"""
+    EvalSquare(crypto_context::CryptoContext, ciphertext::Ciphertext)
+
+Perform efficient homomorphic squaring of a `ciphertext` and return the resulting
+[`Ciphertext`](@ref). The input ciphertext needs to be derived from the given `crypto_context`.
+
+See also: [`CryptoContext`](@ref), [`Ciphertext`](@ref)
+"""
+EvalSquare
+
+"""
+    EvalMultNoRelin(crypto_context::CryptoContext, ciphertext1::Ciphertext, ciphertext2::Ciphertext)
+
+Multiply `ciphertext1` with `ciphertext2` without relinearization and return the resulting
+[`Ciphertext`](@ref). Both input ciphertexts need to be derived from the given `crypto_context`.
+
+See also: [`CryptoContext`](@ref), [`Ciphertext`](@ref)
+"""
+EvalMultNoRelin
+
+"""
+    Relinearize(crypto_context::CryptoContext, ciphertext::Ciphertext)
+
+Perform relinearization of the `ciphertext` to the lowest level (with 2 polynomials per ciphertext)
+and return the resulting [`Ciphertext`](@ref). The input ciphertext needs to be derived from the
+given `crypto_context`.
+
+See also: [`CryptoContext`](@ref), [`Ciphertext`](@ref)
+"""
+Relinearize
+
+"""
+    RelinearizeInPlace(crypto_context::CryptoContext, ciphertext::Ciphertext)
+
+Perfrom in-place relinearization of the `ciphertext` to the lowest level (with 2 polynomials per
+ciphertext). The input ciphertext needs to be derived from the given `crypto_context`.
+
+See also: [`CryptoContext`](@ref), [`Ciphertext`](@ref)
+"""
+RelinearizeInPlace
 
 """
     EvalNegate(crypto_context::CryptoContext, ciphertext::Ciphertext)
@@ -255,17 +342,178 @@ See also: [`CryptoContext`](@ref), [`Ciphertext`](@ref)
 """
 EvalNegate
 
-
 """
     EvalRotate(crypto_context::CryptoContext, ciphertext::Ciphertext, index::Integer)
 
 Rotate the `ciphertext` by the given `index`. A positive index denotes a left shift, a
-negative index a right shift.  The input ciphertext needs to be derived from the given
+negative index a right shift. The input ciphertext needs to be derived from the given
 `crypto_context`.
 
 See also: [`CryptoContext`](@ref), [`Ciphertext`](@ref)
 """
 EvalRotate
+
+"""
+    ComposedEvalMult(crypto_context::CryptoContext, ciphertext1::Ciphertext, ciphertext2::Ciphertext)
+
+Multiply `ciphertext1` with `ciphertext2`, perform relinearization and modulus switching/rescaling.
+Return the resulting [`Ciphertext`](@ref). Both input ciphertexts need to be derived from the
+given `crypto_context`.
+    
+See also: [`CryptoContext`](@ref), [`Ciphertext`](@ref)
+"""
+ComposedEvalMult
+
+"""
+    Rescale(crypto_context::CryptoContext, ciphertext::Ciphertext)
+
+An alias for [`ModReduce`](@ref) method. `ModReduce` is called `Rescale` in CKKS.
+
+Scale down to the original scale of the `ciphertext` and return the resulting [`Ciphertext`](@ref).
+The input ciphertext needs to be derived from the given `crypto_context`.
+    
+See also: [`CryptoContext`](@ref), [`Ciphertext`](@ref), [`ModReduce`](@ref)
+"""
+Rescale
+
+"""
+    RescaleInPlace(crypto_context::CryptoContext, ciphertext::Ciphertext)
+
+An alias for [`ModReduceInPlace`](@ref) method. `ModReduceInPlace` is called `RescaleInPlace` in CKKS.
+        
+Scale down to the original scale of the `ciphertext` in-place. The input ciphertext needs to be
+derived from the given `crypto_context`.
+            
+See also: [`CryptoContext`](@ref), [`Ciphertext`](@ref), [`ModReduceInPlace`](@ref)
+"""
+RescaleInPlace
+
+"""
+    ModReduce(crypto_context::CryptoContext, ciphertext::Ciphertext)
+
+Scale down to the original scale of the `ciphertext` and return the resulting [`Ciphertext`](@ref).
+The input ciphertext needs to be derived from the given `crypto_context`.
+        
+See also: [`CryptoContext`](@ref), [`Ciphertext`](@ref), [`Rescale`](@ref)
+"""
+ModReduce
+
+"""
+    ModReduceInPlace(crypto_context::CryptoContext, ciphertext::Ciphertext)
+            
+Scale down to the original scale of the `ciphertext` in-place. The input ciphertext needs to be
+derived from the given `crypto_context`.
+                
+See also: [`CryptoContext`](@ref), [`Ciphertext`](@ref), [`RescaleInPlace`](@ref)
+"""
+ModReduceInPlace
+
+"""
+    EvalSin(crypto_context::CryptoContext, ciphertext::Ciphertext, a::Float64, b::Float64,
+            degree::UInt32)
+
+Evaluate approximate sine function on a given `ciphertext` using the Chebyshev approximation over
+the range ``[a,b]`` and return the resulting [`Ciphertext`](@ref). The input ciphertext needs to be
+derived from the given `crypto_context`.
+
+`a` is a lower bound of elements contained in the given `ciphertext`.
+
+`b` is an upper bound of elements contained in the given `ciphertext`.
+
+`degree` is a desired degree of approximation.
+
+Supported only in CKKS.
+
+See also: [`CryptoContext`](@ref), [`Ciphertext`](@ref)
+"""
+EvalSin
+
+"""
+    EvalCos(crypto_context::CryptoContext, ciphertext::Ciphertext, a::Float64, b::Float64,
+            degree::UInt32)
+
+Evaluate approximate cosine function on a given `ciphertext` using the Chebyshev approximation over
+the range ``[a,b]`` and return the resulting [`Ciphertext`](@ref). The input ciphertext needs to be
+derived from the given `crypto_context`.
+
+`a` is a lower bound of elements contained in the given `ciphertext`.
+
+`b` is an upper bound of elements contained in the given `ciphertext`.
+
+`degree` is a desired degree of approximation.
+
+Supported only in CKKS.
+
+See also: [`CryptoContext`](@ref), [`Ciphertext`](@ref)
+"""
+EvalCos
+
+"""
+    EvalLogistic(crypto_context::CryptoContext, ciphertext::Ciphertext, a::Float64, b::Float64,
+                 degree::UInt32)
+
+Evaluate approximate logistic function ``\\frac{1}{1 + \\exp{-x}}`` on a given `ciphertext` using
+the Chebyshev approximation over the range ``[a,b]`` and return the resulting [`Ciphertext`](@ref).
+The input ciphertext needs to be derived from the given `crypto_context`.
+
+`x` is an element contained in the given `ciphertext`
+                    
+`a` is a lower bound of elements contained in the given `ciphertext`.
+                    
+`b` is an upper bound of elements contained in the given `ciphertext`.
+                    
+`degree` is a desired degree of approximation.
+                    
+Supported only in CKKS.
+                    
+See also: [`CryptoContext`](@ref), [`Ciphertext`](@ref)             
+"""
+EvalLogistic
+
+"""
+    EvalDivide(crypto_context::CryptoContext, ciphertext::Ciphertext, a::Float64, b::Float64,
+               degree::UInt32)
+
+Evaluate approximate division function ``\\frac{1}{x}`` where ``x >= 1`` on a given `ciphertext`
+using the Chebyshev approximation over the range ``[a,b]`` and return the resulting [`Ciphertext`](@ref).
+The input ciphertext needs to be derived from the given `crypto_context`.
+
+`x` is an element contained in the given `ciphertext`
+                    
+`a` is a lower bound of elements contained in the given `ciphertext`.
+                    
+`b` is an upper bound of elements contained in the given `ciphertext`.
+                    
+`degree` is a desired degree of approximation.
+                    
+Supported only in CKKS.
+                    
+See also: [`CryptoContext`](@ref), [`Ciphertext`](@ref)             
+"""
+EvalDivide
+
+"""
+    EvalSumKeyGen(crypto_context::CryptoContext, private_key::PrivateKey, public_key::PublicKey = nothing)
+
+Generates the key map to be used by [`EvalSum`](@ref). `public_key` has to be set for NTRU schemes.
+
+Please refer to the OpenFHE documentation for more details.
+
+See also: [`CryptoContext`](@ref), [`PrivateKey`](@ref), [`PublicKey`](@ref), [`EvalSum`](@ref)
+"""
+EvalSumKeyGen
+
+"""
+    EvalSum(crypto_context::CryptoContext, ciphertext::Ciphertext, capacity::UInt32)
+    
+Calculate sum of all elements contained in the given `ciphertext` and return the resulting
+[`Ciphertext`](@ref). The input ciphertext needs to be derived from the given `crypto_context`.
+
+`capacity` denotes the maximum length of the ciphertext.
+
+See also: [`CryptoContext`](@ref), [`Ciphertext`](@ref)
+"""
+EvalSum
 
 # `Decrypt` is documented in `src/convenience.jl`
 

--- a/src/documentation.jl
+++ b/src/documentation.jl
@@ -413,7 +413,7 @@ ModReduceInPlace
             degree::UInt32)
 
 Evaluate approximate sine function on a given `ciphertext` using the Chebyshev approximation over
-the range ``[a,b]`` and return the resulting [`Ciphertext`](@ref). The input ciphertext needs to be
+the range ``[a,b]``. Return the resulting [`Ciphertext`](@ref). The input ciphertext needs to be
 derived from the given `crypto_context`.
 
 `a` is a lower bound of elements contained in the given `ciphertext`.
@@ -433,7 +433,7 @@ EvalSin
             degree::UInt32)
 
 Evaluate approximate cosine function on a given `ciphertext` using the Chebyshev approximation over
-the range ``[a,b]`` and return the resulting [`Ciphertext`](@ref). The input ciphertext needs to be
+the range ``[a,b]``. Return the resulting [`Ciphertext`](@ref). The input ciphertext needs to be
 derived from the given `crypto_context`.
 
 `a` is a lower bound of elements contained in the given `ciphertext`.
@@ -453,7 +453,7 @@ EvalCos
                  degree::UInt32)
 
 Evaluate approximate logistic function ``\\frac{1}{1 + \\exp{-x}}`` on a given `ciphertext` using
-the Chebyshev approximation over the range ``[a,b]`` and return the resulting [`Ciphertext`](@ref).
+the Chebyshev approximation over the range ``[a,b]``. Return the resulting [`Ciphertext`](@ref).
 The input ciphertext needs to be derived from the given `crypto_context`.
 
 `x` is an element contained in the given `ciphertext`
@@ -475,7 +475,7 @@ EvalLogistic
                degree::UInt32)
 
 Evaluate approximate division function ``\\frac{1}{x}`` where ``x >= 1`` on a given `ciphertext`
-using the Chebyshev approximation over the range ``[a,b]`` and return the resulting [`Ciphertext`](@ref).
+using the Chebyshev approximation over the range ``[a,b]``. Return the resulting [`Ciphertext`](@ref).
 The input ciphertext needs to be derived from the given `crypto_context`.
 
 `x` is an element contained in the given `ciphertext`

--- a/src/documentation.jl
+++ b/src/documentation.jl
@@ -372,7 +372,7 @@ An alias for [`ModReduce`](@ref) method. `ModReduce` is called `Rescale` in CKKS
 Scale down to the original scale of the `ciphertext` and return the resulting [`Ciphertext`](@ref).
 The input ciphertext needs to be derived from the given `crypto_context`.
     
-See also: [`CryptoContext`](@ref), [`Ciphertext`](@ref), [`ModReduce`](@ref)
+See also: [`CryptoContext`](@ref), [`Ciphertext`](@ref), [`ModReduce`](@ref), [`RescaleInPlace`](@ref)
 """
 Rescale
 

--- a/src/documentation.jl
+++ b/src/documentation.jl
@@ -142,7 +142,7 @@ Enable
 For future use: Return level at which evaluation keys should be generated for the given
 `crypto_context`.
 
-See also: [`CryptoContext`](@ref)
+See also: [`CryptoContext`](@ref), [`SetKeyGenLevel`](@ref)
 """
 GetKeyGenLevel
 

--- a/src/documentation.jl
+++ b/src/documentation.jl
@@ -504,7 +504,7 @@ See also: [`CryptoContext`](@ref), [`PrivateKey`](@ref), [`PublicKey`](@ref), [`
 EvalSumKeyGen
 
 """
-    EvalSum(crypto_context::CryptoContext, ciphertext::Ciphertext, capacity::UInt32)
+    EvalSum(crypto_context::CryptoContext, ciphertext::Ciphertext, batch_size::Integer)
     
 Calculate sum of all elements contained in the given `ciphertext` and return the resulting
 [`Ciphertext`](@ref). The input ciphertext needs to be derived from the given `crypto_context`.

--- a/src/documentation.jl
+++ b/src/documentation.jl
@@ -147,7 +147,7 @@ See also: [`CryptoContext`](@ref)
 GetKeyGenLevel
 
 """
-    SetKeyGenLevel(crypto_context::CryptoContext, level::Unsigned)
+    SetKeyGenLevel(crypto_context::CryptoContext, level::Integer)
 
 For future use: Set `level` at which evaluation keys should be generated for the given
 `crypto_context`.

--- a/src/documentation.jl
+++ b/src/documentation.jl
@@ -152,7 +152,7 @@ GetKeyGenLevel
 For future use: Set `level` at which evaluation keys should be generated for the given
 `crypto_context`.
 
-See also: [`CryptoContext`](@ref)
+See also: [`CryptoContext`](@ref), [`GetKeyGenLevel`](@ref)
 """
 SetKeyGenLevel
 

--- a/src/documentation.jl
+++ b/src/documentation.jl
@@ -492,16 +492,7 @@ See also: [`CryptoContext`](@ref), [`Ciphertext`](@ref)
 """
 EvalDivide
 
-"""
-    EvalSumKeyGen(crypto_context::CryptoContext, private_key::PrivateKey, public_key::PublicKey = nothing)
-
-Generates the key map to be used by [`EvalSum`](@ref). `public_key` has to be set for NTRU schemes.
-
-Please refer to the OpenFHE documentation for more details.
-
-See also: [`CryptoContext`](@ref), [`PrivateKey`](@ref), [`PublicKey`](@ref), [`EvalSum`](@ref)
-"""
-EvalSumKeyGen
+# `EvalSumKeyGen` is documented in `src/convenience.jl`
 
 """
     EvalSum(crypto_context::CryptoContext, ciphertext::Ciphertext, batch_size::Integer)

--- a/src/documentation.jl
+++ b/src/documentation.jl
@@ -430,7 +430,7 @@ EvalSin
 
 """
     EvalCos(crypto_context::CryptoContext, ciphertext::Ciphertext, a::Float64, b::Float64,
-            degree::UInt32)
+            degree::Integer)
 
 Evaluate approximate cosine function on a given `ciphertext` using the Chebyshev approximation over
 the range ``[a,b]``. Return the resulting [`Ciphertext`](@ref). The input ciphertext needs to be

--- a/src/documentation.jl
+++ b/src/documentation.jl
@@ -137,7 +137,7 @@ See also: [`CryptoContext`](@ref), [`PKESchemeFeature`](@ref)
 Enable
 
 """
-    GetKeyGenLevel(crypto_context::CryptoContext)::Unsigned
+    GetKeyGenLevel(crypto_context::CryptoContext)::UInt32
 
 For future use: Return level at which evaluation keys should be generated for the given
 `crypto_context`.

--- a/src/documentation.jl
+++ b/src/documentation.jl
@@ -394,7 +394,7 @@ RescaleInPlace
 Scale down to the original scale of the `ciphertext` and return the resulting [`Ciphertext`](@ref).
 The input ciphertext needs to be derived from the given `crypto_context`.
         
-See also: [`CryptoContext`](@ref), [`Ciphertext`](@ref), [`Rescale`](@ref)
+See also: [`CryptoContext`](@ref), [`Ciphertext`](@ref), [`Rescale`](@ref), [`ModReduceInPlace`](@ref)
 """
 ModReduce
 

--- a/src/documentation.jl
+++ b/src/documentation.jl
@@ -318,7 +318,7 @@ Perform relinearization of the `ciphertext` to the lowest level (with 2 polynomi
 and return the resulting [`Ciphertext`](@ref). The input ciphertext needs to be derived from the
 given `crypto_context`.
 
-See also: [`CryptoContext`](@ref), [`Ciphertext`](@ref)
+See also: [`CryptoContext`](@ref), [`Ciphertext`](@ref), [`RelinearizeInPlace`](@ref)
 """
 Relinearize
 

--- a/src/documentation.jl
+++ b/src/documentation.jl
@@ -384,7 +384,7 @@ An alias for [`ModReduceInPlace`](@ref) method. `ModReduceInPlace` is called `Re
 Scale down to the original scale of the `ciphertext` in-place. The input ciphertext needs to be
 derived from the given `crypto_context`.
             
-See also: [`CryptoContext`](@ref), [`Ciphertext`](@ref), [`ModReduceInPlace`](@ref)
+See also: [`CryptoContext`](@ref), [`Ciphertext`](@ref), [`ModReduceInPlace`](@ref), [`Rescale`](@ref)
 """
 RescaleInPlace
 

--- a/src/documentation.jl
+++ b/src/documentation.jl
@@ -328,7 +328,7 @@ Relinearize
 Perform in-place relinearization of the `ciphertext` to the lowest level (with 2 polynomials per
 ciphertext). The input ciphertext needs to be derived from the given `crypto_context`.
 
-See also: [`CryptoContext`](@ref), [`Ciphertext`](@ref)
+See also: [`CryptoContext`](@ref), [`Ciphertext`](@ref), [`Relinearize`](@ref)
 """
 RelinearizeInPlace
 

--- a/src/documentation.jl
+++ b/src/documentation.jl
@@ -404,7 +404,7 @@ ModReduce
 Scale down to the original scale of the `ciphertext` in-place. The input ciphertext needs to be
 derived from the given `crypto_context`.
                 
-See also: [`CryptoContext`](@ref), [`Ciphertext`](@ref), [`RescaleInPlace`](@ref)
+See also: [`CryptoContext`](@ref), [`Ciphertext`](@ref), [`RescaleInPlace`](@ref), [`ModReduce`](@ref)
 """
 ModReduceInPlace
 

--- a/src/documentation.jl
+++ b/src/documentation.jl
@@ -325,7 +325,7 @@ Relinearize
 """
     RelinearizeInPlace(crypto_context::CryptoContext, ciphertext::Ciphertext)
 
-Perfrom in-place relinearization of the `ciphertext` to the lowest level (with 2 polynomials per
+Perform in-place relinearization of the `ciphertext` to the lowest level (with 2 polynomials per
 ciphertext). The input ciphertext needs to be derived from the given `crypto_context`.
 
 See also: [`CryptoContext`](@ref), [`Ciphertext`](@ref)

--- a/src/documentation.jl
+++ b/src/documentation.jl
@@ -509,8 +509,6 @@ EvalSumKeyGen
 Calculate sum of all elements contained in the given `ciphertext` and return the resulting
 [`Ciphertext`](@ref). The input ciphertext needs to be derived from the given `crypto_context`.
 
-`capacity` denotes the maximum length of the ciphertext.
-
 See also: [`CryptoContext`](@ref), [`Ciphertext`](@ref)
 """
 EvalSum

--- a/src/documentation.jl
+++ b/src/documentation.jl
@@ -444,7 +444,7 @@ derived from the given `crypto_context`.
 
 Supported only in CKKS.
 
-See also: [`CryptoContext`](@ref), [`Ciphertext`](@ref)
+See also: [`CryptoContext`](@ref), [`Ciphertext`](@ref), [`EvalSin`](@ref)
 """
 EvalCos
 

--- a/src/documentation.jl
+++ b/src/documentation.jl
@@ -472,7 +472,7 @@ EvalLogistic
 
 """
     EvalDivide(crypto_context::CryptoContext, ciphertext::Ciphertext, a::Float64, b::Float64,
-               degree::UInt32)
+               degree::Integer)
 
 Evaluate approximate division function ``\\frac{1}{x}`` where ``x >= 1`` on a given `ciphertext`
 using the Chebyshev approximation over the range ``[a,b]``. Return the resulting [`Ciphertext`](@ref).

--- a/test/test_ckks.jl
+++ b/test/test_ckks.jl
@@ -51,6 +51,7 @@ Enable(cc, FHE)
     @test OpenFHE.public_key(keys) isa PublicKey
     @test_nowarn EvalMultKeyGen(cc, OpenFHE.private_key(keys))
     @test_nowarn EvalRotateKeyGen(cc, OpenFHE.private_key(keys), [1, -2])
+    @test_nowarn EvalSumKeyGen(cc, OpenFHE.private_key(keys))
 end
 
 keys = KeyGen(cc)
@@ -58,6 +59,7 @@ privkey = OpenFHE.private_key(keys)
 pubkey = OpenFHE.public_key(keys)
 EvalMultKeyGen(cc, privkey)
 EvalRotateKeyGen(cc, privkey, [1, -2])
+EvalSumKeyGen(cc, privkey)
 
 x1 = [0.25, 0.5, 0.75, 1.0, 2.0, 3.0, 4.0, 5.0]
 x2 = [5.0, 4.0, 3.0, 2.0, 1.0, 0.75, 0.5, 0.25]
@@ -133,6 +135,14 @@ end
     Decrypt(cc, privkey, result_enc, result_dec)
     # Note: Julia's `circshift` rotates in the opposite direction as `EvalRotate`
     @test GetRealPackedValue(result_dec) ≈ circshift(x1, -shift)
+end
+
+@testset verbose=true showtiming=true "EvalSum" begin
+    @test EvalSum(cc, c1, batchSize) isa Ciphertext
+    result_enc = EvalSum(cc, c1, batchSize)
+    result_dec = Plaintext()
+    Decrypt(cc, privkey, result_enc, result_dec)
+    @test GetRealPackedValue(result_dec) ≈ [sum(x1) for _ in range(1, batchSize)]
 end
 
 @testset verbose=true showtiming=true "GetCryptoContext" begin


### PR DESCRIPTION
I added all missing docs for `CryptoContext`. I tried to combine the way of describing these functions in OpenFHE and doc style of OpenFHE.jl, also adding a bit more explanation in tricky places. Hopefully it's what I was supposed to do.
Closes #24