### PR TITLE
Avoid loading libopenfhe_julia_jll when using a custom library

### DIFF
--- a/src/OpenFHE.jl
+++ b/src/OpenFHE.jl
@@ -6,6 +6,10 @@ using UUIDs: UUID
 
 
 # Load library path from preferences or JLL package and wrap OpenFHE module
+# Note: We hide loading the JLL package behind the preferences check since otherwise
+#       we will not be able to test new versions of `libopenfhe_julia` that require an
+#       incompatible version of `libcxxwrap_julia`
+# xref: https://github.com/sloede/OpenFHE.jl/issues/46
 if @has_preference("libopenfhe_julia")
     const libopenfhe_julia_path = @load_preference("libopenfhe_julia")
 else

--- a/src/OpenFHE.jl
+++ b/src/OpenFHE.jl
@@ -1,13 +1,17 @@
 module OpenFHE
 
 using CxxWrap # need to use everything to avoid `UndefVarError`s
-using Preferences: @load_preference, set_preferences!, delete_preferences!
+using Preferences: @has_preference, @load_preference, set_preferences!, delete_preferences!
 using UUIDs: UUID
-using openfhe_julia_jll: libopenfhe_julia
 
 
-# Load library path from preferences and wrap OpenFHE module
-const libopenfhe_julia_path = @load_preference("libopenfhe_julia", libopenfhe_julia)
+# Load library path from preferences or JLL package and wrap OpenFHE module
+if @has_preference("libopenfhe_julia")
+    const libopenfhe_julia_path = @load_preference("libopenfhe_julia")
+else
+    using openfhe_julia_jll: libopenfhe_julia
+    const libopenfhe_julia_path = libopenfhe_julia
+end
 @wrapmodule(() -> libopenfhe_julia_path)
 
 function __init__()


### PR DESCRIPTION
I tried out your suggestion from #46. It works fine on windows and linux, with and without custom library. I tried out to find in the internet whether it's a good programming practice to load package optionally, I didn't find any cons of such approach. I think it's better than apply code formatting like was done https://github.com/sloede/openfhe-julia/pull/35#discussion_r1568317381). So I would suggest to merge this changes. :)